### PR TITLE
Add support for Traefik labels

### DIFF
--- a/src/usr/local/emhttp/plugins/labelman/include/Labelman/Traefik.inc
+++ b/src/usr/local/emhttp/plugins/labelman/include/Labelman/Traefik.inc
@@ -1,0 +1,80 @@
+<?php
+
+namespace Labelman;
+
+/*
+    Copyright (C) 2025  Derek Kaser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+if ( ! isset($this)) {
+    throw new \Exception("Traefik.inc called outside class");
+}
+?>
+
+<dl>
+    <dt>Enabled*</dt>
+    <dd>
+        <select name='traefik_enable' size='1' required>
+            <?= Utils::make_option($this->enable, 'true', "Yes");?>
+            <?= Utils::make_option( ! $this->enable, 'false', "No");?>
+        </select>
+    </dd>
+</dl>
+
+<dl>
+    <dt>Rule(s)*</dt>
+    <dd>
+        <input type="text" name="traefik_rule" value="<?= $this->rule; ?>" placeholder="" required />
+    </dd>
+</dl>
+<blockquote class='inline_help'>Rules are a set of matchers configured with values, that determine if a particular request matches specific criteria. Example: "Host(`domain`)". See <a href="https://doc.traefik.io/traefik/routing/routers/#rule">documentation</a>.</blockquote>
+
+<div class="advanced">
+    <dl>
+        <dt>Entrypoint(s)</dt>
+        <dd>
+            <input type="text" name="traefik_entrypoint" class="narrow" value="<?= $this->entrypoint; ?>" placeholder="" />
+        </dd>
+    </dl>
+    <blockquote class='inline_help'>If not specified, will accept requests from all entrypoints in the <a href="https://doc.traefik.io/traefik/routing/entrypoints/#asdefault">list of default entrypoints</a>.</blockquote>
+
+    <dl>
+        <dt>Certificate Resolver</dt>
+        <dd>
+            <input type="text" name="traefik_certresolver" class="narrow" value="<?= $this->certresolver; ?>" placeholder="" />
+        </dd>
+    </dl>
+    <blockquote class='inline_help'>If `certResolver` is defined, Traefik will try to generate certificates based on routers `Host` & `HostSNI` rules.</blockquote>
+
+    <dl>
+        <dt>Container Port</dt>
+        <dd>
+            <input type="number" name="traefik_container_port" class="narrow" min="0" max="65535" value="<?= $this->container_port > 0 ? $this->container_port : ''; ?>" placeholder="" />
+        </dd>
+    </dl>
+    <blockquote class='inline_help'>Overrides internal exposed port (by default, Traefik uses the first exposed port)</blockquote>
+
+    <dl>
+        <dt>Scheme*</dt>
+        <dd>
+            <select name='traefik_scheme' size='1' required>
+                <?= Utils::make_option($this->scheme == "http", 'http', "HTTP");?>
+                <?= Utils::make_option($this->scheme == "https", 'https', "HTTPS");?>
+            </select>
+        </dd>
+    </dl>
+    <blockquote class='inline_help'>Overrides internal protocol (defaults to HTTP)</blockquote>
+</div>

--- a/src/usr/local/emhttp/plugins/labelman/include/Labelman/Traefik.php
+++ b/src/usr/local/emhttp/plugins/labelman/include/Labelman/Traefik.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Labelman;
+
+/*
+    Copyright (C) 2025  Derek Kaser
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+*/
+
+class Traefik implements Service
+{
+    private string $container_name = "";
+
+    public bool $enable            = false;
+    public string $rule            = "";
+    public string $entrypoint      = "";
+    public string $certresolver    = "";
+    public int $container_port     = 0;
+    public string $scheme          = "http";
+
+    public function __construct(Container $container)
+    {
+        $this->container_name = $container->config->Name;
+
+        $labels = $container->getLabels();
+
+        if (($labels['traefik.enable'] ?? null) == "true") {
+            $this->enable = true;
+        }
+        if (isset($labels[sprintf('traefik.http.routers.%s.rule', $this->container_name)])) {
+            $this->rule = $labels[sprintf('traefik.http.routers.%s.rule', $this->container_name)];
+        }
+        if (isset($labels[sprintf('traefik.http.routers.%s.entrypoints', $this->container_name)])) {
+            $this->entrypoint = $labels[sprintf('traefik.http.routers.%s.entrypoints', $this->container_name)];
+        }
+        if (isset($labels[sprintf('traefik.http.routers.%s.tls.certresolver', $this->container_name)])) {
+            $this->certresolver = $labels[sprintf('traefik.http.routers.%s.tls.certresolver', $this->container_name)];
+        }
+        if (isset($labels[sprintf('traefik.http.services.%s.loadbalancer.server.port', $this->container_name)])) {
+            $this->container_port = intval($labels[sprintf('traefik.http.services.%s.loadbalancer.server.port', $this->container_name)]);
+        }
+        if (isset($labels[sprintf('traefik.http.services.%s.loadbalancer.server.scheme', $this->container_name)])) {
+            $this->scheme = $labels[sprintf('traefik.http.services.%s.loadbalancer.server.scheme', $this->container_name)];
+        }
+    }
+
+    public static function serviceExists(SystemInfo $info): bool
+    {
+        $traefikFound = false;
+        foreach ($info->Images as $image) {
+            if (str_contains(strtolower($image), "traefik")) {
+                $traefikFound = true;
+                break;
+            }
+        }
+
+        return $traefikFound;
+    }
+
+    public static function getDisplayName(): string
+    {
+        return "Traefik";
+    }
+
+    public function display(Container $container): void
+    {
+        include __DIR__ . "/Traefik.inc";
+    }
+
+    public function update(\SimpleXMLElement &$config, array $post): void
+    {
+        if ($this->enable != ($post['traefik_enable'] == "true")) {
+            Utils::apply_label($config, 'traefik.enable', $post['traefik_enable'], "false");
+        }
+
+        if ($this->rule != $post['traefik_rule']) {
+            Utils::apply_label($config, sprintf('traefik.http.routers.%s.rule', $this->container_name), $post['traefik_rule'], "");
+        }
+
+        if ($this->entrypoint != $post['traefik_entrypoint']) {
+            Utils::apply_label($config, sprintf('traefik.http.routers.%s.entrypoints', $this->container_name), $post['traefik_entrypoint'], "");
+        }
+
+        if ($this->certresolver != $post['traefik_certresolver']) {
+            Utils::apply_label($config, sprintf('traefik.http.routers.%s.tls.certresolver', $this->container_name), $post['traefik_certresolver'], "");
+        }
+
+        if ($this->container_port != intval($post['traefik_container_port'])) {
+            Utils::apply_label($config, sprintf('traefik.http.services.%s.loadbalancer.server.port', $this->container_name), $post['traefik_container_port'] ?: "0", "0");
+        }
+
+        if ($this->scheme != $post['traefik_scheme']) {
+            Utils::apply_label($config, sprintf('traefik.http.services.%s.loadbalancer.server.scheme', $this->container_name), $post['traefik_scheme'], "http");
+        }
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enable;
+    }
+}


### PR DESCRIPTION
This PR adds the minimal amount of configurable labels for Traefik proxy.

- `traefik.enable`: To allow Traefik to automatically detect the container
- `traefik.http.routers.<container_name>.rule`: Rules for publishing, e.g. ``Host(`service.example.com`)``
- `traefik.http.routers.<container_name>.entrypoints`: If not specified, will accept requests from all entrypoints in the [list of default entrypoints](https://doc.traefik.io/traefik/routing/entrypoints/#asdefault)
- `traefik.http.routers.<container_name>.tls.certresolver`: If defined, Traefik will try to generate certificates based on routers `Host` & `HostSNI` rules.
- `traefik.http.services.<container_name>.loadbalancer.server.port`: Overrides internal exposed port (by default, Traefik uses the first exposed port)
- `traefik.http.services.<container_name>.loadbalancer.server.scheme`: Overrides internal protocol (defaults to HTTP)

As Traefik theoretically allows multiple configurations per container, I just used the container name as the identifier for the Traefik Routers/Services.

I tested this on my own Unraid server and was pleased with the results.